### PR TITLE
[FEAT] ErrorCode Enum 작성 (#6)

### DIFF
--- a/backend-janghak/build.gradle
+++ b/backend-janghak/build.gradle
@@ -27,11 +27,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorCode.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.learning_mate.janghakrun.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 시스템
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYSTEM_001", "서버 에러가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "SYSTEM_002", "잘못된 요청입니다."),
+
+    // 인증 인가
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "AUTH_003", "아이디 또는 비밀번호가 올바르지 않습니다."),
+
+    // 도메인
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "DOMAIN_001", "요청한 리소스를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- close #5

## ✨ PR 세부 내용

- 초기 예외 처리 구조 정립을 위한 ErrorCode enum 추가
- SYSTEM / AUTH / DOMAIN 기반으로 에러코드 분류
- HTTP Status, 코드 문자열(prefix 포함), 메시지 필드 구성
