### PR TITLE
[FEAT]: 전역 예외처리 초기 세팅 (#14)

### DIFF
--- a/backend-janghak/build.gradle
+++ b/backend-janghak/build.gradle
@@ -27,11 +27,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/BusinessException.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/BusinessException.java
@@ -1,0 +1,15 @@
+package com.learning_mate.janghakrun.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorCode.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.learning_mate.janghakrun.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 시스템
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYSTEM_001", "서버 에러가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "SYSTEM_002", "잘못된 요청입니다."),
+
+    // 인증 인가
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "AUTH_003", "아이디 또는 비밀번호가 올바르지 않습니다."),
+
+    // 도메인
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "DOMAIN_001", "요청한 리소스를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorResponse.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.learning_mate.janghakrun.global.error;
+
+public record ErrorResponse(
+    int httpStatus,
+    String code,
+    String message
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+}
+

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/GlobalExceptionHandler.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.learning_mate.janghakrun.global.error;
+
+import com.learning_mate.janghakrun.global.exception.BusinessException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 로직 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    // 그 외 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/exception/BusinessException.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/exception/BusinessException.java
@@ -1,5 +1,6 @@
-package com.learning_mate.janghakrun.global.error;
+package com.learning_mate.janghakrun.global.exception;
 
+import com.learning_mate.janghakrun.global.error.ErrorCode;
 import lombok.Getter;
 
 @Getter


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #4 

## ✨ PR 세부 내용

- 전역 예외 처리 초기 세팅
  - `ErrorCode` enum 정의
    - SYSTEM / AUTH / DOMAIN 등으로 에러 코드 분류
    - 각 코드에 HttpStatus, 코드 문자열, 기본 메시지 매핑
  - `ErrorResponse` record 구현
    - `status`, `code`, `message` 필드 정의
    - `ErrorCode` 기반으로 응답 객체를 생성하는 `of(ErrorCode)` 정적 메서드 추가
  - `BusinessException` 구현 (`global.exception`)
    - `RuntimeException` 상속 및 `ErrorCode` 필드 보유
    - 도메인 로직에서 `throw new BusinessException(ErrorCode.XXX)` 형태로 사용 가능하도록 기반 마련
  - `GlobalExceptionHandler` 구현 (`global.error`)
    - `@RestControllerAdvice` 기반 전역 예외 처리
    - `BusinessException` 발생 시 `ErrorCode` → `ErrorResponse`로 변환하여 응답
    - 처리되지 않은 예외에 대해 `INTERNAL_SERVER_ERROR` 응답 반환
