### PR TITLE
[FEAT] swagger 연결 설정 추가 (#15)

### DIFF
--- a/backend-janghak/build.gradle
+++ b/backend-janghak/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SwaggerConfig.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.learning_mate.janghakrun.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+            title = "장학런 API",
+            description = "장학런 백엔드 API 명세",
+            version = "v1"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+    private static final String SECURITY_SCHEME_NAME = "JWT"; // Swagger UI에서 보이는 이름
+    private static final String BEARER_FORMAT = "JWT"; // bearer 토큰 포맷 설정
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+
+        Components components = new Components()
+                .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                        .name(SECURITY_SCHEME_NAME)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat(BEARER_FORMAT));
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #13 

## ✨ PR 세부 내용

- springdoc-openapi 의존성 추가 (`springdoc-openapi-starter-webmvc-ui`)
- Swagger/OpenAPI 설정용 `SwaggerConfig` 클래스 생성
  - API title, description, version 메타데이터 설정
  - JWT 토큰 사용을 위한 SecurityScheme(`bearer`, `JWT`) 등록
  - 전역 SecurityRequirement 추가로 기본적으로 JWT 인증을 요구하도록 설정