### PR TITLE
[FEAT] spring security 기본 설정 추가 (#17)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.learning_mate.janghakrun.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 비활성화 (JWT 쓸 예정)
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // JWT 기반 인증만 사용
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // 요청 인가 규칙
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml"
+                        ).permitAll()
+
+                        // TODO: 인증 붙인 이후 authenticated()로 변경
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #16 

## ✨ PR 세부 내용

- Spring Security 기본 설정 추가 (`SecurityConfig` 생성)
- CSRF 비활성화 및 세션을 사용하지 않는 `STATELESS` 전략 설정
- 폼 로그인(`formLogin`) 및 HTTP Basic 인증(`httpBasic`) 비활성화 (JWT 기반 인증만 사용 예정)
- Swagger/OpenAPI 경로(`/swagger-ui/**`, `/v3/api-docs/**`, `/v3/api-docs.yaml`)는 `permitAll()`로 허용
- 그 외 요청은 현재 개발 단계에서는 `anyRequest().permitAll()`로 설정 (추후 JWT + 인증 적용 시 `authenticated()`로 변경 예정)
