### PR TITLE
[FEAT] 로그인 요청/응답 dto 추가 (#20)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginReqeust.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginReqeust.java
@@ -1,0 +1,11 @@
+package com.learning_mate.janghakrun.auth.request;
+
+/*
+ * 로그인 요청 DTO
+ * 요청 필드 변경될 수 있음
+ */
+public record LoginReqeust(
+        String id,
+        String password
+) {
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/response/LoginResponse.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/response/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.learning_mate.janghakrun.auth.response;
+
+public record LoginResponse(
+        String accessToken
+) {
+    public static LoginResponse of(String accessToken) {
+        return new LoginResponse(accessToken);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #19 

## ✨ PR 세부 내용

- 로그인 요청 DTO 추가
  - `auth.request.LoginRequest` : email, password 필드 정의
- 로그인 응답 DTO 추가
  - `auth.response.LoginResponse` : accessToken 필드만 포함
  - `LoginResponse.of(String accessToken)` 정적 메서드로 응답 생성 편의 제공