### PR TITLE
[FEAT] 로그인 api 기본 구조 추가 (close #23)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/controller/AuthController.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.learning_mate.janghakrun.auth.controller;
+
+import com.learning_mate.janghakrun.auth.request.LoginRequest;
+import com.learning_mate.janghakrun.auth.response.LoginResponse;
+import com.learning_mate.janghakrun.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginRequest.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginRequest.java
@@ -4,7 +4,7 @@ package com.learning_mate.janghakrun.auth.request;
  * 로그인 요청 DTO
  * 요청 필드 변경될 수 있음
  */
-public record LoginReqeust(
+public record LoginRequest(
         String id,
         String password
 ) {

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
@@ -1,0 +1,20 @@
+package com.learning_mate.janghakrun.auth.service;
+
+import com.learning_mate.janghakrun.auth.request.LoginRequest;
+import com.learning_mate.janghakrun.auth.response.LoginResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    public LoginResponse login(LoginRequest request) {
+        // TODO: user 조회
+
+        // TODO: 비밀번호 검증
+
+        // TODO: JWT로 accessToken 생성
+
+        String token = "";
+        return LoginResponse.of(token);
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #21 

## ✨ PR 세부 내용

- 로그인 API 기본 구조 추가
  - `AuthController` 생성
    - `POST /api/v1/auth/login` 엔드포인트 구현
    - `LoginRequest`를 입력으로 받고 `LoginResponse`를 반환
  - `AuthService` 생성
    - 데모용 더미 accessToken을 생성하여 `LoginResponse`로 감싸서 반환
- 이후 단계에서 User 조회, 비밀번호 검증, JWT 발급 로직으로 교체 예정
