### PR TITLE
[FEAT]: JWT 연동 및 Security 설정 (#42)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.learning_mate.janghakrun.config;
 
+import com.learning_mate.janghakrun.security.jwt.JwtAuthenticationFilter;
+import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,12 +11,23 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 // CSRF 비활성화 (JWT 쓸 예정)
                 .csrf(AbstractHttpConfigurer::disable)
@@ -35,7 +49,10 @@ public class SecurityConfig {
 
                         // TODO: 인증 붙인 이후 authenticated()로 변경
                         .anyRequest().permitAll()
-                );
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        ;
 
         return http.build();
     }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtAuthenticationFilter.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.learning_mate.janghakrun.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if(token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * header에서 Bearer 토큰 추출
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        return (bearerToken != null && bearerToken.startsWith("Bearer "))
+                ? bearerToken.substring(7) : null;
+    }
+
+    /**
+     * Jwt 추출 -> Authentication 객체로 변환
+     */
+    private Authentication getAuthentication(String token) {
+        Long userId = jwtTokenProvider.getUserID(token);
+
+        // TODO: CustomDetailsService 작성 후 UserDetails로 조회 교체
+        return new UsernamePasswordAuthenticationToken(
+                userId, null, Collections.emptyList()
+        );
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close 24
- close #36 

## ✨ PR 세부 내용

현재는 userId 기반 인증이며 이후 CustomUserDetailsService / UserDetails 기반 인증 구조로 확장 예정입니다.

- JWT 인증 필터 `JwtAuthenticationFilter` 추가
  - `resolveToken()`으로 Authorization 헤더에서 토큰 추출
  - `jwtTokenProvider.validateToken()`으로 유효성 검증
  - `getUserId()`로 사용자 식별 ID 추출
  - 해당 ID로 `Authentication` 생성 후 `SecurityContext`에 저장
- `JwtAuthenticationFilter`를 Spring Bean으로 등록
- SecurityConfig에 필터 연동
  - CSRF/HTTP Basic/FormLogin 비활성화
  - Stateless 세션 사용 설정
  - Swagger 관련 URL permitAll 처리
  - `addFilterBefore()`로 JWT 필터를 Security Filter Chain에 추가

