### PR TITLE
[FEAT] 로그인용 User, Auth 엔티티 및 레포지토리 추가 (#44)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/domain/Auth.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/domain/Auth.java
@@ -1,0 +1,42 @@
+    package com.learning_mate.janghakrun.auth.domain;
+
+    import com.learning_mate.janghakrun.user.domain.User;
+    import jakarta.persistence.*;
+    import lombok.AllArgsConstructor;
+    import lombok.Builder;
+    import lombok.Getter;
+    import lombok.NoArgsConstructor;
+
+    @Entity
+    @Table(name = "auth")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public class Auth {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "user_id", nullable = false)
+        private User user;
+
+        @Enumerated(EnumType.STRING)
+        @Column(name = "provider", nullable = false, length = 20)
+        private AuthProvider provider;
+
+        // LOCAL 전용 로그인 이메일
+        @Column(name = "email", length = 50)
+        private String email;
+
+        // LOCAL 전용 비밀번호 hash
+        @Column(name = "password")
+        private String password;
+
+        // OAuth provider에서 주는 user id
+        @Column(name = "provider_user_id", length = 100)
+        private String providerUserId;
+
+    }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/domain/AuthProvider.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/domain/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.learning_mate.janghakrun.auth.domain;
+
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/repository/AuthRepository.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/repository/AuthRepository.java
@@ -1,0 +1,15 @@
+package com.learning_mate.janghakrun.auth.repository;
+
+import com.learning_mate.janghakrun.auth.domain.Auth;
+import com.learning_mate.janghakrun.auth.domain.AuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthRepository extends JpaRepository<Auth, Long> {
+    // LOCAL 로그인
+    Optional<Auth> findByProviderAndEmail(AuthProvider provider, String email);
+
+    // OAuth 로그인
+    Optional<Auth> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/Repository/UserRepository.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/Repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.learning_mate.janghakrun.user.Repository;
+
+import com.learning_mate.janghakrun.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 기본 crud만
+}
+

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/domain/User.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/domain/User.java
@@ -1,0 +1,26 @@
+package com.learning_mate.janghakrun.user.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50)
+    private String email;
+
+    @Column(length = 15)
+    private String phoneNumber;
+
+    // TODO: User 기능 구현 시 다른 필드들 작성
+}

--- a/backend-janghak/src/main/resources/application.yaml
+++ b/backend-janghak/src/main/resources/application.yaml
@@ -4,4 +4,4 @@ spring:
 
 jwt:
   secret: ${jwt.secret}
-  access-token-validity-in-seconds: 86400 #24h
+  access-token-validity-in-seconds: 2592000 #30일


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #43 

## ✨ PR 세부 내용

- User 엔티티 추가
  - id, email, phoneNumber 필드 정의
- Auth 엔티티 추가
  - user(FK), provider, email, password, providerUserId 필드 정의
  - User와 ManyToOne 단방향 매핑
- AuthProvider enum 추가
- UserRepository, AuthRepository 인터페이스 추가


<!-- 수정/추가한 내용을 적어주세요. -->
