### PR TITLE
[FEAT] JWT 필터와 CustomUserDetails 연동 (#46)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
@@ -1,64 +1,69 @@
-package com.learning_mate.janghakrun.config;
+    package com.learning_mate.janghakrun.config;
 
-import com.learning_mate.janghakrun.security.jwt.JwtAuthenticationFilter;
-import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+    import com.learning_mate.janghakrun.security.CustomUserDetails;
+    import com.learning_mate.janghakrun.security.CustomUserDetailsService;
+    import com.learning_mate.janghakrun.security.jwt.JwtAuthenticationFilter;
+    import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.context.annotation.Bean;
+    import org.springframework.context.annotation.Configuration;
+    import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+    import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+    import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+    import org.springframework.security.config.http.SessionCreationPolicy;
+    import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+    import org.springframework.security.web.SecurityFilterChain;
+    import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@Configuration
-@EnableWebSecurity
-@RequiredArgsConstructor
-public class SecurityConfig {
+    @Configuration
+    @EnableWebSecurity
+    @RequiredArgsConstructor
+    public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
+        private final JwtTokenProvider jwtTokenProvider;
+        private final CustomUserDetailsService customUserDetailsService;
 
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtTokenProvider);
+        @Bean
+        public JwtAuthenticationFilter jwtAuthenticationFilter() {
+            return new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService);
+        }
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                       JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+            http
+                    // CSRF 비활성화 (JWT 쓸 예정)
+                    .csrf(AbstractHttpConfigurer::disable)
+
+                    .sessionManagement(session -> session
+                            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                    // JWT 기반 인증만 사용
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable)
+
+                    // 요청 인가 규칙
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers(
+                                    "/swagger-ui/**",
+                                    "/v3/api-docs/**",
+                                    "/v3/api-docs.yaml",
+
+                                    "/auth/login"
+                            ).permitAll()
+
+                            .anyRequest().authenticated()
+                    )
+                    .userDetailsService(customUserDetailsService)
+
+                    .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            ;
+
+            return http.build();
+        }
+
+        @Bean
+        public BCryptPasswordEncoder bCryptPasswordEncoder() {
+            return new BCryptPasswordEncoder();
+        }
     }
-
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http,
-                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
-        http
-                // CSRF 비활성화 (JWT 쓸 예정)
-                .csrf(AbstractHttpConfigurer::disable)
-
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // JWT 기반 인증만 사용
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-
-                // 요청 인가 규칙
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs.yaml"
-                        ).permitAll()
-
-                        // TODO: 인증 붙인 이후 authenticated()로 변경
-                        .anyRequest().permitAll()
-                )
-
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-        ;
-
-        return http.build();
-    }
-
-    @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/CustomUserDetails.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.learning_mate.janghakrun.security;
+
+import com.learning_mate.janghakrun.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 역할/권한 구분X
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/CustomUserDetailsService.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.learning_mate.janghakrun.security;
+
+import com.learning_mate.janghakrun.user.repository.UserRepository;
+import com.learning_mate.janghakrun.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        Long id = Long.parseLong(userId);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
+        return new CustomUserDetails(user);
+    }
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtAuthenticationFilter.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.learning_mate.janghakrun.security.jwt;
 
+import com.learning_mate.janghakrun.security.CustomUserDetails;
+import com.learning_mate.janghakrun.security.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +19,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -47,11 +50,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * Jwt 추출 -> Authentication 객체로 변환
      */
     private Authentication getAuthentication(String token) {
-        Long userId = jwtTokenProvider.getUserID(token);
+        Long userId = jwtTokenProvider.getUserId(token);
 
-        // TODO: CustomDetailsService 작성 후 UserDetails로 조회 교체
+        CustomUserDetails userDetails =
+                (CustomUserDetails) customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+
         return new UsernamePasswordAuthenticationToken(
-                userId, null, Collections.emptyList()
+                userDetails, null, userDetails.getAuthorities()
         );
     }
 }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtTokenProvider.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/security/jwt/JwtTokenProvider.java
@@ -64,7 +64,7 @@ public class JwtTokenProvider {
      * @param token
      * @return 추출된 userId
      */
-    public Long getUserID(String token) {
+    public Long getUserId(String token) {
         Claims claims = parseClaims(token);
         return Long.parseLong(claims.getSubject());
     }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/repository/UserRepository.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/user/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.learning_mate.janghakrun.user.Repository;
+package com.learning_mate.janghakrun.user.repository;
 
 import com.learning_mate.janghakrun.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #45 

## ✨ PR 세부 내용

- CustomUserDetails 추가
  - User 엔티티를 기반으로 하는 UserDetails 구현
  - userId를 username으로 사용하고, 권한은 빈 리스트로 처리

- CustomUserDetailsService 추가
  - UserDetailsService 구현
  - userId(String)를 Long으로 변환 후 UserRepository로 사용자 조회

- JwtAuthenticationFilter 수정
  - CustomUserDetailsService로 UserDetails를 조회하여 Authentication 구성
  - SecurityContextHolder에 Authentication 설정

- SecurityConfig 수정
  - JwtAuthenticationFilter Bean 등록
  - UsernamePasswordAuthenticationFilter 이전에 JWT 필터 추가
  - `/auth/login는 permitAll, 나머지 경로는 인증 필요

<!-- 수정/추가한 내용을 적어주세요. -->
