### PR TITLE
[FEAT] 로그인 서비스 로직 구현(close #48)

### DIFF
--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginRequest.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/request/LoginRequest.java
@@ -5,7 +5,7 @@ package com.learning_mate.janghakrun.auth.request;
  * 요청 필드 변경될 수 있음
  */
 public record LoginRequest(
-        String id,
+        String email,
         String password
 ) {
 }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
@@ -1,20 +1,40 @@
 package com.learning_mate.janghakrun.auth.service;
 
+import com.learning_mate.janghakrun.auth.domain.Auth;
+import com.learning_mate.janghakrun.auth.domain.AuthProvider;
+import com.learning_mate.janghakrun.auth.repository.AuthRepository;
 import com.learning_mate.janghakrun.auth.request.LoginRequest;
 import com.learning_mate.janghakrun.auth.response.LoginResponse;
+import com.learning_mate.janghakrun.global.error.ErrorCode;
+import com.learning_mate.janghakrun.global.exception.BusinessException;
+import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
     public LoginResponse login(LoginRequest request) {
-        // TODO: user 조회
 
-        // TODO: 비밀번호 검증
+        // user 조회
+        Auth auth = authRepository.findByProviderAndEmail(AuthProvider.LOCAL, request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
 
-        // TODO: JWT로 accessToken 생성
+        // 비밀번호 검증
+        if(!passwordEncoder.matches(request.password(), auth.getPassword())) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
 
-        String token = "";
+        // JWT로 accessToken 생성
+        Long userId = auth.getUser().getId();
+        String token = jwtTokenProvider.createToken(userId);
+
         return LoginResponse.of(token);
     }
 }

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/GlobalExceptionHandler.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/global/error/GlobalExceptionHandler.java
@@ -20,11 +20,11 @@ public class GlobalExceptionHandler {
 
     // 그 외 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(BusinessException e) {
-        ErrorCode errorCode = e.getErrorCode();
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
 
         return ResponseEntity
-                .status(errorCode.getHttpStatus())
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(ErrorResponse.of(errorCode));
     }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #47

## ✨ PR 세부 내용

- AuthService.login 구현
  - provider=LOCAL, email 기준으로 Auth 조회
  - 비밀번호 불일치 및 사용자 미존재 시 BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS) 발생
  - 인증 성공 시 userId를 기반으로 JWT accessToken 생성 후 LoginResponse 반환

- GlobalExceptionHandler 수정
  - BusinessException용 핸들러에서 ErrorCode 기반 ErrorResponse 반환
  - 그 외 일반 Exception은 INTERNAL_SERVER_ERROR로 공통 처리

<!-- 수정/추가한 내용을 적어주세요. -->
