### PR TITLE
[FEAT] 구글 OAuth2 연동(#52)

### DIFF
--- a/backend-janghak/build.gradle
+++ b/backend-janghak/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/oauth/CustomOAuth2UserService.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,82 @@
+package com.learning_mate.janghakrun.auth.oauth;
+
+import com.learning_mate.janghakrun.auth.domain.Auth;
+import com.learning_mate.janghakrun.auth.domain.AuthProvider;
+import com.learning_mate.janghakrun.auth.repository.AuthRepository;
+import com.learning_mate.janghakrun.user.domain.User;
+import com.learning_mate.janghakrun.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final AuthRepository authRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        // 유저 정보 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // 실제 값 꺼내기
+        String providerUserId = String.valueOf(attributes.get(userNameAttributeName));
+        String email = (String) attributes.get("email");
+
+        // 우리 user와 매핑
+        // 현재는 google만 지원 (OAuth 추가 시 provider 별로 case 작성)
+        Auth auth = authRepository
+                .findByProviderAndProviderUserId(AuthProvider.GOOGLE, providerUserId)
+                .orElseGet(() -> createUserAndAuth(providerUserId, email));
+
+        Long userId = auth.getUser().getId();
+
+        // SpringContext에 넣을 OAuth2User
+        Map<String, Object> extendAttributes = Map.of(
+                userNameAttributeName, providerUserId,
+                "email", email,
+                "userId", userId
+        );
+
+        return new DefaultOAuth2User(
+                oAuth2User.getAuthorities(),
+                extendAttributes,
+                userNameAttributeName
+        );
+
+    }
+
+    /**
+     * 처음 로그인하는 회원의 경우 회원가입
+     */
+    private Auth createUserAndAuth(String providerUserId, String email) {
+        User user = User.builder()
+                .email(email)
+                .phoneNumber(null)
+                .build();
+        userRepository.save(user);
+
+        Auth auth = Auth.builder()
+                .user(user)
+                .provider(AuthProvider.GOOGLE)
+                .providerUserId(providerUserId)
+                .email(email)
+                .build();
+
+        return authRepository.save(auth);
+    }
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,40 @@
+package com.learning_mate.janghakrun.auth.oauth;
+
+import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private static final String urlPrefix = "http://localhost:3000/oauth2/success?token=";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        // principal에서 userId 가져오기
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Long userId = ((Number) oAuth2User.getAttributes().get("userId")).longValue();
+
+        String token = jwtTokenProvider.createToken(userId);
+
+        String redirectUrl = urlPrefix + token;
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+
+}

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/auth/service/AuthService.java
@@ -9,11 +9,13 @@ import com.learning_mate.janghakrun.global.error.ErrorCode;
 import com.learning_mate.janghakrun.global.exception.BusinessException;
 import com.learning_mate.janghakrun.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final AuthRepository authRepository;

--- a/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
+++ b/backend-janghak/src/main/java/com/learning_mate/janghakrun/config/SecurityConfig.java
@@ -1,5 +1,10 @@
     package com.learning_mate.janghakrun.config;
 
+    import com.fasterxml.jackson.databind.ObjectMapper;
+    import com.learning_mate.janghakrun.auth.oauth.CustomOAuth2UserService;
+    import com.learning_mate.janghakrun.auth.oauth.OAuth2LoginSuccessHandler;
+    import com.learning_mate.janghakrun.global.error.ErrorCode;
+    import com.learning_mate.janghakrun.global.error.ErrorResponse;
     import com.learning_mate.janghakrun.security.CustomUserDetails;
     import com.learning_mate.janghakrun.security.CustomUserDetailsService;
     import com.learning_mate.janghakrun.security.jwt.JwtAuthenticationFilter;
@@ -22,6 +27,9 @@
 
         private final JwtTokenProvider jwtTokenProvider;
         private final CustomUserDetailsService customUserDetailsService;
+        private final CustomOAuth2UserService customOAuth2UserService;
+        private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+        private final ObjectMapper objectMapper;
 
         @Bean
         public JwtAuthenticationFilter jwtAuthenticationFilter() {
@@ -49,12 +57,33 @@
                                     "/v3/api-docs/**",
                                     "/v3/api-docs.yaml",
 
-                                    "/auth/login"
+                                    "/api/v1/auth/login",
+                                    "/oauth2/**",           // oauth 로그인
+                                    "/login/oauth2/**"      // oauth callback
                             ).permitAll()
 
                             .anyRequest().authenticated()
                     )
                     .userDetailsService(customUserDetailsService)
+
+                    // oauth 설정
+                    .oauth2Login(oauth -> oauth
+                                    .userInfoEndpoint(userInfo -> userInfo
+                                    .userService(customOAuth2UserService)
+                                    )
+                                    .successHandler(oAuth2LoginSuccessHandler)
+                            )
+
+                    // 로그인이 필요한 페이지로 이동할 시 Error 반환
+                    .exceptionHandling(e -> e
+                            .authenticationEntryPoint((request, response, authException) -> {
+                                ErrorResponse body = ErrorResponse.of(ErrorCode.AUTH_UNAUTHORIZED);
+
+                                response.setStatus(body.httpStatus());
+                                response.setContentType("application/json;charset=UTF-8");
+                                response.getWriter().write(objectMapper.writeValueAsString(body));
+                            })
+                    )
 
                     .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             ;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- close #51 

## ✨ PR 세부 내용

1. OAuth 클라이언트 설정 추가
   - `application.yml`에 `spring.security.oauth2.client.registration.google` 설정 추가
   - Google Cloud Console에 `http://localhost:8080/login/oauth2/code/google` 리다이렉트 URI 등록

2. Google OAuth 사용자 정보 → 도메인 매핑
   - `CustomOAuth2UserService` 추가
     - Google 사용자 정보 조회
     - `Auth(AuthProvider.GOOGLE, providerUserId)` 기준으로 회원 조회/생성
     - `User`가 없을 경우 자동 회원가입 후 `Auth`와 매핑
     - `OAuth2User` attributes에 `userId`, `email` 등을 포함하도록 확장

3. OAuth2 로그인 성공 처리 및 JWT 발급
   - `OAuth2LoginSuccessHandler` 추가
     - 로그인 성공 시 Principal에서 `userId` 추출
     - `JwtTokenProvider`로 액세스 토큰 발급
     - `http://localhost:3000/oauth2/success?token={JWT}`로 리다이렉트

4. SecurityConfig 보안 설정 정리
   - `oauth2Login`에 `CustomOAuth2UserService`, `OAuth2LoginSuccessHandler` 연동
   - 인증 실패 시 JSON 에러 응답을 내려주는 `authenticationEntryPoint` 설정

### 기타

현재 test용 yml 파일로 login test 마친 상태입니다 (local login -> postman, google oauth -> 직접 url 접근)
postgresql은 일단 로컬로 설정했습니다
test용 yml 파일 따로 두어 테스트 진행해보았고, 이후 oauth, jwt 관련 key는 추후 요청 시 전달해드리겠습니다
